### PR TITLE
Refactor chat session repository methods to include user_id for aliasupdates and deletions

### DIFF
--- a/api/src/repository/chat_session.py
+++ b/api/src/repository/chat_session.py
@@ -32,12 +32,12 @@ class ChatSessionRepository(ABC):
         pass
     
     @abstractmethod
-    def update_alias(self, session_id: str, alias: str) -> Optional[ChatSession]:
+    def update_alias(self, user_id: int, session_id: str, alias: str) -> Optional[ChatSession]:
         """Update session alias."""
         pass
     
     @abstractmethod
-    def delete_by_id(self, session_id: str) -> bool:
+    def delete_by_id(self, user_id: int, session_id: str) -> bool:
         """Delete a session by ID."""
         pass
     
@@ -55,8 +55,10 @@ class ChatSessionSqliteRepository(ChatSessionRepository):
     
     def create(self, user_id: int, session_id: str, alias: str) -> ChatSession:
         """Create a new chat session."""
+        # Prefix session_id with user_id for uniqueness
+        prefixed_session_id = f"{user_id}_{session_id}"
         session = ChatSession(
-            id=session_id,
+            id=prefixed_session_id,
             user_id=user_id,
             alias=alias,
             created_at=datetime.datetime.now(datetime.timezone.utc),
@@ -79,9 +81,11 @@ class ChatSessionSqliteRepository(ChatSessionRepository):
     
     def find_by_user_and_session(self, user_id: int, session_id: str) -> Optional[ChatSession]:
         """Find a specific session for a user."""
+        # Prefix session_id with user_id for uniqueness
+        prefixed_session_id = f"{user_id}_{session_id}"
         return self.db.query(ChatSession).filter(
             ChatSession.user_id == user_id,
-            ChatSession.id == session_id
+            ChatSession.id == prefixed_session_id
         ).first()
     
     def update_alias(self, user_id: int, session_id: str, alias: str) -> Optional[ChatSession]:
@@ -94,10 +98,12 @@ class ChatSessionSqliteRepository(ChatSessionRepository):
             self.db.refresh(session)
         return session
     
-    def delete_by_id(self, session_id: str) -> bool:
+    def delete_by_id(self, user_id: int, session_id: str) -> bool:
         """Delete a session by ID."""
+        # Prefix session_id with user_id for uniqueness
+        prefixed_session_id = f"{user_id}_{session_id}"
         deleted_count = self.db.query(ChatSession).filter(
-            ChatSession.id == session_id
+            ChatSession.id == prefixed_session_id
         ).delete()
         self.db.commit()
         return deleted_count > 0

--- a/api/src/services/chat.py
+++ b/api/src/services/chat.py
@@ -246,7 +246,7 @@ class AgentChatService(ChatService):
         deleted_messages = self.chat_repo.delete_by_user_id_and_session(user_id, session_id)
         
         # Delete the session record
-        self.session_repo.delete_by_id(session_id)
+        self.session_repo.delete_by_id(user_id, session_id)
         
         logger.debug(f"Deleted session {session_id} and {deleted_messages} messages for user {user_id}")
         


### PR DESCRIPTION
This pull request updates the chat session repository and related service logic to ensure session IDs are unique per user by prefixing them with the user ID. This change helps prevent session ID collisions across different users and improves session management consistency. The most important changes are grouped below:

Repository interface and implementation changes:

* Updated the method signatures in `chat_session.py` to require `user_id` for `update_alias` and `delete_by_id`, ensuring session operations are always scoped to a specific user.
* Modified the session creation logic to prefix `session_id` with `user_id`, guaranteeing uniqueness of session records.
* Updated session lookup, alias update, and delete operations to use the prefixed session ID, ensuring all queries are user-specific. [[1]](diffhunk://#diff-21f20312c2dd41a18fb446a0f082deecdd488312dd1ac3612f59996962b255ffR84-R88) [[2]](diffhunk://#diff-21f20312c2dd41a18fb446a0f082deecdd488312dd1ac3612f59996962b255ffL97-R106)

Service layer changes:

* Updated the `delete_session` method in `chat.py` to pass both `user_id` and `session_id` when deleting a session, aligning with the new repository interface.